### PR TITLE
ci: use better dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,18 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
+      interval: "daily"
+    commit-message:
+      prefix: "fix(deps)"
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci(deps)"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "ci(deps)"


### PR DESCRIPTION
Part of https://github.com/schueco/platform-team-organization/issues/16